### PR TITLE
Added options + catch shift+tab case

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,38 +1,76 @@
 // returns pencil button HTMLButtonElement or null
 function getPencilButton() {
-  const pencilButtonIconInactive = document.querySelector(".xwd__toolbar_icon--pencil")
-  const pencilButtonIconActive = document.querySelector(".xwd__toolbar_icon--pencil-active")
-  const pencilButtonAcrostic = document.querySelector(".acrostic-tool__pencil") // inactive or active
-  let pencilButton = null
+  const pencilButtonIconInactive = document.querySelector(
+    ".xwd__toolbar_icon--pencil"
+  );
+  const pencilButtonIconActive = document.querySelector(
+    ".xwd__toolbar_icon--pencil-active"
+  );
+  const pencilButtonAcrostic = document.querySelector(".acrostic-tool__pencil"); // inactive or active
+  let pencilButton = null;
   if (pencilButtonIconInactive) {
-    pencilButton = pencilButtonIconInactive.closest("button")
+    pencilButton = pencilButtonIconInactive.closest("button");
   }
   if (pencilButtonIconActive) {
-    pencilButton = pencilButtonIconActive.closest("button")
+    pencilButton = pencilButtonIconActive.closest("button");
   }
   if (pencilButtonAcrostic) {
-    pencilButton = pencilButtonAcrostic.closest("button")
+    pencilButton = pencilButtonAcrostic.closest("button");
   }
-  return pencilButton ?? null
+  return pencilButton ?? null;
 }
 
 function togglePencilButton() {
-  const pencilButton = getPencilButton()
-  pencilButton?.click()
+  const pencilButton = getPencilButton();
+  pencilButton?.click();
 }
 
-function onKeyPress(event) {
-  if (event.code === "ShiftLeft") {
-    togglePencilButton()
+const defaultKeyCode = "ShiftLeft";
+let keyCode = defaultKeyCode;
+let tabShifted = false;
+
+function onKeyUp(event) {
+  if((keyCode === "AltLeft" || keyCode === "AltRight") && event.key === "Alt"){
+    event.preventDefault(); //Alt key navigates to 3 dots top right in Chrome
+  }
+  if (event.code === "Tab" && event.shiftKey) {
+    //keeps track if tab was clicked during shift, to prevent conflict between shift pencil hotkey and shift+tab to navigate crossword
+    tabShifted = true;
+  }
+  if (event.code === keyCode && !tabShifted) {
+    togglePencilButton();
+  }
+  if (event.key === "Shift") {
+    tabShifted = false;
   }
 }
 
 function addKeyListener() {
-  window.addEventListener("keydown", onKeyPress)
+  window.addEventListener("keyup", onKeyUp);
 }
 
+const getOptions = () => {
+  try {
+    chrome.storage.sync.get(["NYTPencilExtensionOptions"], (result) => {
+      const settings = result.NYTPencilExtensionOptions;
+      if (settings) {
+        keyCode = settings.pencilKeyCode ?? defaultKeyCode;
+      } else {
+        keyCode = defaultKeyCode;
+      }
+    });
+  } catch (error) {
+    keyCode = defaultKeyCode;
+    console.error(
+      "Error getting NYTPencilExtensionOptions from storage",
+      error
+    );
+  }
+};
+
 try {
-  addKeyListener()
+  getOptions();
+  addKeyListener();
 } catch (error) {
-  console.error("Content-script error:", error)
+  console.error("Content-script error:", error);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,10 @@
   "name": "NYT Crossword Pencil Toggle",
   "description": "On the New York Times' Crossword site, press the Left Shift key to toggle the pencil tool.",
   "version": "1.0",
-
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
   "icons": {
     "16": "favicon/favicon-16x16.png",
     "32": "favicon/favicon-32x32.png",
@@ -31,6 +34,7 @@
   ],
   "permissions": [
    "activeTab",
-   "scripting"
+   "scripting",
+   "storage"
   ]
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>NYT Pencil Extension Options</title>
+</head>
+
+<body>
+    <div id="Options" style="margin-bottom:1em;">
+        <label for="KeyCode">Pencil shortcut key:</label>
+        <select id="KeyCode">
+            <option value="ShiftLeft">Left Shift</option>
+            <option value="ShiftRight">Right Shift</option>
+            <option value="ControlLeft">Left Ctrl</option>
+            <option value="ControlRight">Right Ctrl</option>
+            <option value="AltLeft">Left Alt</option>
+            <option value="AltRight">Right Alt / AltGr</option>
+        </select>
+    </div>
+    <button id="save">Save</button>
+    <div id="status"></div>
+
+    <script src="options.js"></script>
+</body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,34 @@
+const NYTPencilExtensionOptions = "NYTPencilExtensionOptions";
+const DefaultPencilKeyCode = "ShiftLeft";
+const KeyCodeId = "KeyCode";
+const StatusId = "status";
+
+// Saves options to chrome.storage
+const saveOptions = () => {
+  const keyCode = document.getElementById(KeyCodeId).value;
+
+  chrome.storage.sync.set(
+    { NYTPencilExtensionOptions: { pencilKeyCode: keyCode } },
+    () => {
+      // Update status to let user know options were saved.
+      const status = document.getElementById(StatusId);
+      status.textContent = "Options saved.";
+      setTimeout(() => {
+        status.textContent = "";
+      }, 1500);
+    }
+  );
+};
+
+// Restores select box with value stored in chrome.storage.
+const restoreOptions = () => {
+  chrome.storage.sync.get(
+    { NYTPencilExtensionOptions: { pencilKeyCode: `${DefaultPencilKeyCode}` } },
+    (items) => {
+      document.getElementById(KeyCodeId).value = items.NYTPencilExtensionOptions.pencilKeyCode;
+    }
+  );
+};
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.getElementById("save").addEventListener("click", saveOptions);


### PR DESCRIPTION
Added options.html & options.js as embedded options on the extensions page:
![image](https://github.com/user-attachments/assets/abcd4006-f286-4654-99b9-45157e664b9a)
![image](https://github.com/user-attachments/assets/aaa184b0-600b-4a5b-97b6-6373a4c1dbc2)

Changed to `keyup` event instead of keydown to enable checking for `Shift+Tab` combination.
(Tab doesn't trigger on the `keydown` event, took a while before I noticed)